### PR TITLE
Sign up page name surname validation missing

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -53,5 +53,6 @@
                 <button type="submit" class="signup-btn">Sign Up</button>
         </form>
     </div>
+    <script src="signup.js"></script>
 </body>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -1,5 +1,5 @@
 // Regular expression for name validation
-const nameRegex = /^[A-Za-z\s-]{4,50}$/;
+const nameRegex = /^[A-Za-z\s-]{2,50}$/;
 
 // Function to validate input fields
 function validateNameField(inputField, fieldName) {
@@ -23,8 +23,8 @@ function validateNameField(inputField, fieldName) {
     errorDiv.textContent = `${fieldName} is required.`;
     inputField.style.borderColor = "red";
     return false;
-  } else if (value.length < 4) {
-    errorDiv.textContent = `${fieldName} must be at least 4 characters long.`;
+  } else if (value.length < 2) {
+    errorDiv.textContent = `${fieldName} must be at least 2 characters long.`;
     inputField.style.borderColor = "red";
     return false;
   } else if (value.length > 50) {

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,69 @@
+// Regular expression for name validation
+const nameRegex = /^[A-Za-z\s-]{4,50}$/;
+
+// Function to validate input fields
+function validateNameField(inputField, fieldName) {
+  const value = inputField.value.trim();
+  const errorId = `${inputField.id}-error`;
+  let errorDiv = document.getElementById(errorId);
+
+  // Create error div if it doesn't exist
+  if (!errorDiv) {
+    errorDiv = document.createElement("div");
+    errorDiv.id = errorId;
+    errorDiv.className = "error-message";
+    errorDiv.style.color = "red";
+    errorDiv.style.fontSize = "12px";
+    errorDiv.style.marginTop = "5px";
+    inputField.parentNode.appendChild(errorDiv);
+  }
+
+  // Validation checks
+  if (value.length === 0) {
+    errorDiv.textContent = `${fieldName} is required.`;
+    inputField.style.borderColor = "red";
+    return false;
+  } else if (value.length < 4) {
+    errorDiv.textContent = `${fieldName} must be at least 4 characters long.`;
+    inputField.style.borderColor = "red";
+    return false;
+  } else if (value.length > 50) {
+    errorDiv.textContent = `${fieldName} must not exceed 50 characters.`;
+    inputField.style.borderColor = "red";
+    return false;
+  } else if (!nameRegex.test(value)) {
+    errorDiv.textContent = `${fieldName} can only contain letters, spaces, and hyphens.`;
+    inputField.style.borderColor = "red";
+    return false;
+  } else {
+    errorDiv.textContent = "";
+    inputField.style.borderColor = "initial";
+    return true;
+  }
+}
+
+// Add event listeners when the document loads
+document.addEventListener("DOMContentLoaded", function () {
+  const nameInput = document.getElementById("name");
+  const surnameInput = document.getElementById("surname");
+  const form = document.querySelector("form");
+
+  // Real-time validation
+  nameInput.addEventListener("input", function () {
+    validateNameField(this, "Name");
+  });
+
+  surnameInput.addEventListener("input", function () {
+    validateNameField(this, "Surname");
+  });
+
+  // Form submission validation
+  form.addEventListener("submit", function (event) {
+    const isNameValid = validateNameField(nameInput, "Name");
+    const isSurnameValid = validateNameField(surnameInput, "Surname");
+
+    if (!isNameValid || !isSurnameValid) {
+      event.preventDefault();
+    }
+  });
+});


### PR DESCRIPTION
## Description ##
The issue was related to the absence of name and surname field validation so, to address the missing Name & Surname field validation on the Sign-Up page, the following criteria were implemented:

1. Allowed Characters: Only alphabetic characters, spaces, and hyphens are permitted (e.g., "Mary-Anne" or "John Doe").
2. Length Restriction: Input must be between 2 and 50 characters.
3. Disallowed Inputs: Special characters and numbers are restricted to ensure valid entries like "John123" or "Mary@Home" are 
    flagged invalid.
Validation is enforced using a regex pattern (^[A-Za-z\s-]{2,50}$) on both the front-end and back-end, ensuring consistent and secure data entry.

## Attachments ##

![image](https://github.com/user-attachments/assets/236e1396-ef92-4cbb-8e56-d3cb575d0f4c)

If box is left empty after clicking on it once it shows this message.

![image](https://github.com/user-attachments/assets/bdf3a912-0c5e-4159-bf79-f4f73197301f)

If Input characters are less than 2 then it alerts user to put name between 2-50 characters

![image](https://github.com/user-attachments/assets/ff81480d-9328-4111-8b07-78fa76b8634d)

Use of special characters cannot be done except "-"

Resolves : #58 