### PR TITLE
fixed home page blog content

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -465,6 +465,14 @@ body::-webkit-scrollbar-thumb{
   transition: transform 0.5s ease, box-shadow 0.3s ease;
 }
 
+@media(max-width:500px){
+
+  .blog-card{
+    max-width:90vw;
+  }
+}
+
+
 .blog-card:hover {
   transform: translateY(-10px);
   box-shadow: 0px 10px 30px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
The blog content was entirely disoriented in the mobile view . The issue has been fixed now.
(Under SWOC)

before
<img width="266" alt="{8E7B9AF5-7143-4705-B54F-8AA523FF4C9E}" src="https://github.com/user-attachments/assets/d5f4b49a-c138-4eaf-b575-f5688d448a0e" />

after
<img width="206" alt="{F00A5E9A-851D-4E8F-AC22-20D7EB870E57}" src="https://github.com/user-attachments/assets/d27a8ef5-6574-4de3-9264-06accb1d94cc" />


