### PR TITLE
contributor's name visibility fixed

### DIFF
--- a/contributors/contributor.css
+++ b/contributors/contributor.css
@@ -67,6 +67,7 @@ h1 {
   position: relative;
   border: 2px solid transparent;
   animation: pulse 2s infinite;
+  color:#000000;
 }
 
 .contributor-card:hover {


### PR DESCRIPTION
Contributors' name were not visible for the names listed below the top two rows. The issue has been fixed.(under swoc)

BEFORE
![image](https://github.com/user-attachments/assets/aa6f9429-b83e-4d6d-85c6-676c2d328f00)

AFTER
![image](https://github.com/user-attachments/assets/b9a7edfc-a76d-44e6-a452-2740df63b020)
